### PR TITLE
pygame expects move() as integer

### DIFF
--- a/source/Bin/Minibloq/lang/PPythonWin/v2.7.5.1/App/Lib/miniSim.py
+++ b/source/Bin/Minibloq/lang/PPythonWin/v2.7.5.1/App/Lib/miniSim.py
@@ -153,7 +153,7 @@ class MobileRobot(pygame.sprite.Sprite):
         step = 5;
         distance = int(distance)
         if (math.fabs(distance) > step):
-            distanceRange = distance/step
+            distanceRange = distance//step
         else:
             distanceRange = distance
         if distance <= 0:


### PR DESCRIPTION
Small fix for Python3 / latest pygame version which require an integer to be passed to `move()`