### PR TITLE
miniSim: Linux + system-wide Python board-file changes

### DIFF
--- a/source/Bin/Minibloq/hard/miniSim.v0.2/main.board
+++ b/source/Bin/Minibloq/hard/miniSim.v0.2/main.board
@@ -81,8 +81,8 @@
 	</finalCode>
 	<build>
 		<cmd>
-			<s>"</s><s>toolsPath::</s><s>/Python-Portable.exe"</s>
-			<s> "</s><s>componentFilesPath::</s><s>/</s><s>componentName::</s><s>.py"</s>
+			<s>"bash" "-c" "PYTHONPATH='</s><s>toolsPath::</s><s>/App/Lib</s><s>' /usr/bin/python3 </s>
+			<s> '</s><s>componentFilesPath::</s><s>/</s><s>componentName::</s><s>.py'"</s>
 		</cmd>
 	</build>
 	<deploy>


### PR DESCRIPTION
The only way I could find to actually:
- Run system-wide python3
- ...overriding PYTHONPATH to load miniSim
- ...using `toolsPath::` variable-interpolation
- without having to alter Bubble.cpp with `wxSetEnv(PYTHONPATH)` things

Not Windows-friendly but definitely handy for Linux user and worth an example (or maybe a a "source/Bin/Minibloq/hard/miniSim.v0.2/main.**linux**.board" file?)